### PR TITLE
Refactor

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,136 +1,224 @@
-name: pytorch
+name: template
 channels:
+  - anaconda
   - simpleitk
   - pytorch
+  - bioconda
   - conda-forge
   - defaults
 dependencies:
-  - _tflow_select=2.1.0=gpu
-  - absl-py=0.7.1=py37_0
-  - astor=0.7.1=py37_0
-  - atomicwrites=1.3.0=py37_1
-  - attrs=19.1.0=py37_1
+  - _libgcc_mutex=0.1=main
+  - _pytorch_select=0.1=cpu_0
+  - _tflow_select=2.3.0=mkl
+  - absl-py=0.9.0=py37_0
+  - asn1crypto=1.3.0=py37_0
+  - astor=0.8.0=py37_0
+  - astroid=2.3.3=py37_0
+  - attrs=19.3.0=py_0
+  - autopep8=1.4.4=py_0
   - backcall=0.1.0=py37_0
   - blas=1.0=mkl
-  - c-ares=1.15.0=h7b6447c_1
-  - ca-certificates=2019.5.15=0
-  - certifi=2019.3.9=py37_0
-  - cffi=1.12.3=py37h2e261b9_0
-  - cloudpickle=1.1.1=py_0
+  - bleach=3.1.0=py37_0
+  - blinker=1.4=py37_0
+  - bz2file=0.98=py37_1
+  - bzip2=1.0.8=h7b6447c_0
+  - c-ares=1.15.0=h7b6447c_1001
+  - ca-certificates=2020.1.1=0
+  - cachetools=3.1.1=py_0
+  - cairo=1.14.12=h8948797_3
+  - certifi=2019.11.28=py37_1
+  - cffi=1.14.0=py37h2e261b9_0
+  - chardet=3.0.4=py37_1003
+  - click=7.1.1=py_0
+  - cloudpickle=1.3.0=py_0
+  - conda=4.8.3=py37_0
+  - conda-package-handling=1.6.0=py37h7b6447c_0
+  - coverage=5.0=py37h7b6447c_0
+  - cryptography=2.8=py37h1ba5d50_0
   - cudatoolkit=10.0.130=0
-  - cudnn=7.6.0=cuda10.0_0
+  - cudnn=7.6.5=cuda10.0_0
   - cupti=10.0.130=0
   - cycler=0.10.0=py37_0
-  - cytoolz=0.9.0.1=py37h14c3975_1
-  - dask-core=1.2.2=py_0
-  - dbus=1.13.6=h746ee38_0
-  - decorator=4.4.0=py37_1
+  - cython=0.29.15=py37he6710b0_0
+  - cytoolz=0.10.1=py37h7b6447c_0
+  - dask-core=2.13.0=py_0
+  - dbus=1.13.12=h746ee38_0
+  - dcm2niix=1.0.20190902=hc9558a2_0
+  - decorator=4.4.2=py_0
+  - defusedxml=0.6.0=py_0
+  - entrypoints=0.3=py37_0
   - expat=2.2.6=he6710b0_0
+  - ffmpeg=4.0=hcdf2ecd_0
+  - flake8=3.7.9=py37_0
   - fontconfig=2.13.0=h9420a91_0
+  - freeglut=3.0.0=hf484d3e_5
   - freetype=2.9.1=h8a8886c_1
-  - future=0.17.1=py37_0
-  - gast=0.2.2=py37_0
-  - glib=2.56.2=hd408876_0
-  - grpcio=1.16.1=py37hf8bcb03_1
+  - gast=0.3.3=py_0
+  - gdcm=2.8.9=py37h71b2a6d_0
+  - glib=2.63.1=h5a9c865_0
+  - gmp=6.1.2=h6c8ec71_1
+  - google-auth=1.11.2=py_0
+  - google-auth-oauthlib=0.4.1=py_2
+  - google-pasta=0.2.0=py_0
+  - graphite2=1.3.13=h23475e2_0
+  - grpcio=1.27.2=py37hf8bcb03_0
   - gst-plugins-base=1.14.0=hbbd80ab_1
   - gstreamer=1.14.0=hb453b48_1
-  - h5py=2.9.0=py37h7918eee_0
-  - hdf5=1.10.4=hb1b8bf9_0
+  - h5py=2.8.0=py37h3010b51_1003
+  - harfbuzz=1.8.8=hffaf4a1_0
+  - hdf5=1.10.2=hba1933b_1
   - icu=58.2=h9c2bf20_1
-  - imageio=2.5.0=py37_0
-  - importlib_metadata=0.17=py37_1
-  - intel-openmp=2019.4=243
-  - ipdb=0.12=py_0
-  - ipykernel=5.1.1=py37h39e3cac_0
-  - ipython=7.5.0=py37h39e3cac_0
+  - idna=2.9=py_1
+  - imageio=2.8.0=py_0
+  - importlib_metadata=1.5.0=py37_0
+  - intel-openmp=2020.0=166
+  - ipdb=0.12.3=py_0
+  - ipykernel=5.1.4=py37h39e3cac_0
+  - ipython=7.13.0=py37h5ca1d4c_0
   - ipython_genutils=0.2.0=py37_0
-  - jedi=0.13.3=py37_0
+  - ipywidgets=7.5.1=py_0
+  - isort=4.3.21=py37_0
+  - jasper=2.0.14=h07fcdf6_1
+  - jedi=0.16.0=py37_1
+  - jinja2=2.11.1=py_0
+  - joblib=0.14.1=py_0
   - jpeg=9b=h024ee3a_2
-  - jupyter_client=5.2.4=py37_0
-  - jupyter_core=4.4.0=py37_0
-  - keras-applications=1.0.8=py_0
-  - keras-preprocessing=1.1.0=py_1
+  - json-c=0.13.1=h1bed415_0
+  - jsonschema=3.2.0=py37_0
+  - jupyter=1.0.0=py37_7
+  - jupyter_client=6.1.0=py_0
+  - jupyter_console=6.1.0=py_0
+  - jupyter_core=4.6.1=py37_0
   - kiwisolver=1.1.0=py37he6710b0_0
+  - lazy-object-proxy=1.4.3=py37h7b6447c_0
+  - ld_impl_linux-64=2.33.1=h53a641e_7
   - libedit=3.1.20181209=hc058e9b_0
   - libffi=3.2.1=hd88cf55_4
-  - libgcc-ng=8.2.0=hdf63c60_1
+  - libgcc-ng=9.1.0=hdf63c60_0
   - libgfortran-ng=7.3.0=hdf63c60_0
+  - libglu=9.0.0=hf484d3e_1
+  - libjpeg-turbo=2.0.3=h516909a_1
+  - libopencv=3.4.2=hb342d67_1
+  - libopus=1.3=h7b6447c_0
   - libpng=1.6.37=hbc83047_0
-  - libprotobuf=3.8.0=hd408876_0
+  - libprotobuf=3.11.4=hd408876_0
   - libsodium=1.0.16=h1bed415_0
-  - libstdcxx-ng=8.2.0=hdf63c60_1
-  - libtiff=4.0.10=h2733197_2
+  - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libtiff=4.1.0=h2733197_0
   - libuuid=1.0.3=h1bed415_2
+  - libvpx=1.7.0=h439df22_0
   - libxcb=1.13=h1bed415_1
-  - libxml2=2.9.9=he19cac6_0
+  - libxml2=2.9.9=hea5a465_1
   - markdown=3.1.1=py37_0
-  - matplotlib=3.1.0=py37h5429711_0
-  - mkl=2019.4=243
-  - mkl_fft=1.0.12=py37ha843d7b_0
-  - mkl_random=1.0.2=py37hd81dba3_0
-  - mock=3.0.5=py37_0
-  - more-itertools=7.0.0=py37_0
-  - ncurses=6.1=he6710b0_1
-  - networkx=2.3=py_0
+  - markupsafe=1.1.1=py37h7b6447c_0
+  - matplotlib=3.1.3=py37_0
+  - matplotlib-base=3.1.3=py37hef1b27d_0
+  - mccabe=0.6.1=py37_1
+  - medpy=0.4.0=py_0
+  - mistune=0.8.4=py37h7b6447c_0
+  - mkl=2020.0=166
+  - mkl-include=2020.0=166
+  - mkl-service=2.3.0=py37he904b0f_0
+  - mkl_fft=1.0.15=py37ha843d7b_0
+  - mkl_random=1.1.0=py37hd6b4f25_0
+  - more-itertools=8.2.0=py_0
+  - nbconvert=5.6.1=py37_0
+  - nbformat=5.0.4=py_0
+  - ncurses=6.2=he6710b0_0
+  - networkx=2.4=py_0
+  - nibabel=2.5.1=py_0
   - ninja=1.9.0=py37hfd86e86_0
-  - numpy=1.16.4=py37h7e9f1db_0
-  - numpy-base=1.16.4=py37hde5b4d6_0
+  - notebook=6.0.3=py37_0
+  - numpy=1.18.1=py37h4f9e942_0
+  - numpy-base=1.18.1=py37hde5b4d6_1
+  - oauthlib=3.1.0=py_0
   - olefile=0.46=py37_0
-  - openssl=1.1.1c=h7b6447c_1
-  - packaging=19.0=py37_0
-  - parso=0.4.0=py_0
+  - opencv=3.4.2=py37h6fd60c2_1
+  - openjpeg=2.3.0=h05c96fa_1
+  - openssl=1.1.1e=h7b6447c_0
+  - opt_einsum=3.1.0=py_0
+  - packaging=20.3=py_0
+  - pandas=1.0.3=py37h0573a6f_0
+  - pandoc=2.2.3.2=0
+  - pandocfilters=1.4.2=py37_1
+  - parso=0.6.2=py_0
   - pcre=8.43=he6710b0_0
-  - pexpect=4.7.0=py37_0
+  - pexpect=4.8.0=py37_0
   - pickleshare=0.7.5=py37_0
-  - pillow=6.0.0=py37h34e0f95_0
-  - pip=19.1.1=py37_0
-  - pluggy=0.12.0=py_0
-  - prompt_toolkit=2.0.9=py37_0
-  - protobuf=3.8.0=py37he6710b0_0
+  - pillow=7.0.0=py37hb39fc2d_0
+  - pip=20.0.2=py37_1
+  - pixman=0.38.0=h7b6447c_0
+  - pluggy=0.13.1=py37_0
+  - prometheus_client=0.7.1=py_0
+  - prompt-toolkit=3.0.4=py_0
+  - prompt_toolkit=3.0.4=0
+  - protobuf=3.11.4=py37he6710b0_0
   - ptyprocess=0.6.0=py37_0
-  - py=1.8.0=py37_0
-  - pycparser=2.19=py37_0
-  - pygments=2.4.2=py_0
-  - pyparsing=2.4.0=py_0
+  - py=1.8.1=py_0
+  - py-opencv=3.4.2=py37hb342d67_1
+  - pyasn1=0.4.8=py_0
+  - pyasn1-modules=0.2.7=py_0
+  - pycodestyle=2.5.0=py37_0
+  - pycosat=0.6.3=py37h7b6447c_0
+  - pycparser=2.20=py_0
+  - pydicom=1.3.0=py_0
+  - pyflakes=2.1.1=py37_0
+  - pygments=2.6.1=py_0
+  - pyjwt=1.7.1=py37_0
+  - pylint=2.4.4=py37_0
+  - pyopenssl=19.1.0=py37_0
+  - pyparsing=2.4.6=py_0
   - pyqt=5.9.2=py37h05f1152_2
-  - pytest=4.6.2=py37_0
-  - python=3.7.3=h0371630_0
-  - python-box=3.4.0=py_0
-  - python-dateutil=2.8.0=py37_0
-  - pytorch=1.1.0=py3.7_cuda10.0.130_cudnn7.5.1_0
-  - pytz=2019.1=py_0
-  - pywavelets=1.0.3=py37hdd07704_1
-  - pyyaml=5.1=py37h7b6447c_0
-  - pyzmq=18.0.0=py37he6710b0_0
+  - pyrsistent=0.15.7=py37h7b6447c_0
+  - pysocks=1.7.1=py37_0
+  - pytest=5.4.1=py37_0
+  - pytest-cov=2.8.1=py_0
+  - python=3.7.7=hcf32534_0_cpython
+  - python-box=3.4.6=py_0
+  - python-dateutil=2.8.1=py_0
+  - pytorch=1.4.0=py3.7_cuda10.0.130_cudnn7.6.3_0
+  - pytz=2019.3=py_0
+  - pywavelets=1.1.1=py37h7b6447c_0
+  - pyyaml=5.3.1=py37h7b6447c_0
+  - pyzmq=18.1.1=py37he6710b0_0
   - qt=5.9.7=h5867ecd_1
-  - readline=7.0=h7b6447c_5
-  - scikit-image=0.15.0=py37he6710b0_0
-  - scipy=1.2.1=py37h7c811a0_0
-  - setuptools=41.0.1=py37_0
-  - simpleitk=1.2.0=py37hf484d3e_0
+  - qtconsole=4.7.2=py_0
+  - qtpy=1.9.0=py_0
+  - readline=8.0=h7b6447c_0
+  - requests=2.23.0=py37_0
+  - requests-oauthlib=1.3.0=py_0
+  - rsa=4.0=py_0
+  - ruamel_yaml=0.15.87=py37h7b6447c_0
+  - scikit-image=0.16.2=py37h0573a6f_0
+  - scikit-learn=0.22.1=py37hd81dba3_0
+  - scipy=1.4.1=py37h0b6359f_0
+  - send2trash=1.5.0=py37_0
+  - setuptools=46.1.1=py37_0
+  - simpleitk=1.2.4=py37hf484d3e_0
   - sip=4.19.8=py37hf484d3e_0
-  - six=1.12.0=py37_0
-  - sqlite=3.28.0=h7b6447c_0
-  - tensorboard=1.13.1=py37hf484d3e_0
-  - tensorflow=1.13.1=gpu_py37hc158e3b_0
-  - tensorflow-base=1.13.1=gpu_py37h8d69cac_0
-  - tensorflow-estimator=1.13.0=py_0
-  - tensorflow-gpu=1.13.1=h0d30ee6_0
+  - six=1.14.0=py37_0
+  - sqlite=3.31.1=h7b6447c_0
+  - tensorboard=2.1.0=py3_0
   - termcolor=1.1.0=py37_1
+  - terminado=0.8.3=py37_0
+  - testpath=0.4.4=py_0
   - tk=8.6.8=hbc83047_0
-  - toolz=0.9.0=py37_0
-  - torchvision=0.3.0=py37_cu10.0.130_1
-  - tornado=6.0.2=py37h7b6447c_0
-  - tqdm=4.32.1=py_0
-  - traitlets=4.3.2=py37_0
-  - wcwidth=0.1.7=py37_0
-  - werkzeug=0.15.4=py_0
-  - wheel=0.33.4=py37_0
+  - toolz=0.10.0=py_0
+  - torchvision=0.5.0=py37_cu100
+  - tornado=6.0.4=py37h7b6447c_1
+  - tqdm=4.43.0=py_0
+  - traitlets=4.3.3=py37_0
+  - typing=3.6.4=py37_0
+  - urllib3=1.25.8=py37_0
+  - wcwidth=0.1.8=py_0
+  - webencodings=0.5.1=py37_1
+  - werkzeug=1.0.0=py_0
+  - wheel=0.34.2=py37_0
+  - widgetsnbextension=3.5.1=py37_0
+  - wrapt=1.12.1=py37h7b6447c_1
   - xz=5.2.4=h14c3975_4
   - yaml=0.1.7=had09818_2
   - zeromq=4.3.1=he6710b0_3
-  - zipp=0.5.1=py_0
+  - zipp=2.2.0=py_0
   - zlib=1.2.11=h7b6447c_3
   - zstd=1.3.7=h0b5b093_0
-  - pip:
-    - tb-nightly==1.14.0a20190604

--- a/src/callbacks/monitor.py
+++ b/src/callbacks/monitor.py
@@ -51,7 +51,12 @@ class Monitor:
         Returns:
             path (Path): The path to save the model checkpoint.
         """
-        score = valid_log[self.target]
+        score = valid_log.get(self.target)
+        if score is None:
+            raise KeyError(f"The valid_log has no key named '{self.target}'. "
+                           f'Its keys: {list(valid_log.keys())}.\n'
+                           'Please check the returned keys as defined in MyTrainer._valid_step().')
+
         if self.mode == 'max' and score > self.best:
             self.best = score
             self.not_improved_count = 0

--- a/src/callbacks/monitor.py
+++ b/src/callbacks/monitor.py
@@ -12,28 +12,29 @@ class Monitor:
         mode (str): The mode of the monitor ('max' or 'min') (default: 'min').
         target (str): The target of the monitor ('loss', 'my_loss' or 'my_metric') (default: 'loss').
         saved_freq (int): The saved frequency (default: 1).
-        early_stop (int): The number of times to early stop the training if monitor target is not improved
-            (default: 0, do not early stop the training). Notice that the unit is validation times, not epoch.
         valid_freq (int): The validation frequency (default: 1).
+        early_stop (int): The number of times to early stop the training if monitor target is not improved
+            (default: 0, do not early stop the training). Notice that the unit is valid_freq, not epoch.
     """
 
-    def __init__(self, checkpoints_dir, mode='min', target='loss', saved_freq=1, early_stop=0, valid_freq=1):
+    def __init__(self, checkpoints_dir, mode='min', target='loss', saved_freq=1, valid_freq=1, early_stop=0):
         self.checkpoints_dir = checkpoints_dir
         if mode not in ['min', 'max']:
             raise ValueError(f"The mode should be 'min' or 'max'. Got {mode}.")
         self.mode = mode
         self.target = target
         self.saved_freq = saved_freq
-        self.early_stop = math.inf if early_stop == 0 else early_stop
         self.valid_freq = valid_freq
-        self.best = -math.inf if self.mode == 'max' else math.inf
+        self.early_stop = math.inf if early_stop == 0 else early_stop
+        self.best_epoch = 0
+        self.best_score = -math.inf if self.mode == 'max' else math.inf
         self.not_improved_count = 0
 
         if not self.checkpoints_dir.is_dir():
             self.checkpoints_dir.mkdir(parents=True)
 
     def is_saved(self, epoch):
-        """Whether to save the model checkpoint.
+        """Whether to save the regular model checkpoint.
         Args:
             epoch (int): The number of trained epochs.
 
@@ -45,9 +46,10 @@ class Monitor:
         else:
             return None
 
-    def is_best(self, valid_log):
+    def is_best(self, epoch, valid_log):
         """Whether to save the best model checkpoint.
         Args:
+            epoch (int): The number of trained epochs.
             valid_log (dict): The validation log information.
 
         Returns:
@@ -59,12 +61,9 @@ class Monitor:
                            f'Its keys: {list(valid_log.keys())}.\n'
                            'Please check the returned keys as defined in MyTrainer._valid_step().')
 
-        if self.mode == 'max' and score > self.best:
-            self.best = score
-            self.not_improved_count = 0
-            return self.checkpoints_dir / 'model_best.pth'
-        elif self.mode == 'min' and score < self.best:
-            self.best = score
+        if (self.mode == 'max' and score > self.best_score) or (self.mode == 'min' and score < self.best_score):
+            self.best_epoch = epoch
+            self.best_score = score
             self.not_improved_count = 0
             return self.checkpoints_dir / 'model_best.pth'
         else:
@@ -81,31 +80,36 @@ class Monitor:
             'mode': self.mode,
             'target': self.target,
             'saved_freq': self.saved_freq,
+            'valid_freq': self.valid_freq,
             'early_stop': self.early_stop,
-            'best': self.best,
-            'not_improved_count': self.not_improved_count,
-            'valid_freq': self.valid_freq
+            'best_epoch': self.best_epoch,
+            'best_score': self.best_score,
+            'not_improved_count': self.not_improved_count
         }
 
     def load_state_dict(self, state_dict):
         if self.mode == state_dict['mode'] and self.target == state_dict['target']:
-            self.best = state_dict['best']
+            self.best_epoch = state_dict['best_epoch']
+            self.best_score = state_dict['best_score']
             self.not_improved_count = state_dict['not_improved_count']
         else:
-            LOGGER.warning(f"The mode and target are changed from "
-                           f"{state_dict['mode']} {state_dict['target']} to {self.mode} {self.target}.")
+            LOGGER.warning('The mode and target are changed from '
+                           f"{state_dict['mode']} {state_dict['target']} to {self.mode} {self.target}. "
+                           'Note that the best_epoch, best_score and not_improved_count are not loaded.')
 
         if self.saved_freq != state_dict['saved_freq']:
             LOGGER.warning(f"The saved_freq is changed from {state_dict['saved_freq']} to {self.saved_freq}.")
 
+        if self.valid_freq != state_dict['valid_freq']:
+            LOGGER.warning(f"The valid_freq is changed from {state_dict['valid_freq']} to {self.valid_freq}. "
+                           f'Note that the not_improved_count is {self.not_improved_count} '
+                           f'and the early_stop is {self.early_stop}.')
+
         if self.early_stop != state_dict['early_stop']:
             LOGGER.warning(f"The early_stop is changed from {state_dict['early_stop']} to {self.early_stop}.")
 
-        if self.valid_freq != state_dict['valid_freq']:
-            self.not_improved_count = 0
-            LOGGER.warning(f"The valid_freq is changed from {state_dict['valid_freq']} to {self.valid_freq}.")
-            LOGGER.warning(f"The not_improved_count is reset to 0.")
-
         if self.not_improved_count >= self.early_stop:
-            LOGGER.critical(f"Load the checkpoint that should have to be early stopped.")
+            LOGGER.critical('Load the checkpoint that should have to be early stopped '
+                            f'(i.e., not_improved_count={self.not_improved_count} '
+                            f'is greater than or equal to early_stop={self.early_stop}).')
             sys.exit()

--- a/src/callbacks/monitor.py
+++ b/src/callbacks/monitor.py
@@ -14,9 +14,10 @@ class Monitor:
         saved_freq (int): The saved frequency (default: 1).
         early_stop (int): The number of times to early stop the training if monitor target is not improved
             (default: 0, do not early stop the training). Notice that the unit is validation times, not epoch.
+        valid_freq (int): The validation frequency (default: 1).
     """
 
-    def __init__(self, checkpoints_dir, mode='min', target='loss', saved_freq=1, early_stop=0):
+    def __init__(self, checkpoints_dir, mode='min', target='loss', saved_freq=1, early_stop=0, valid_freq=1):
         self.checkpoints_dir = checkpoints_dir
         if mode not in ['min', 'max']:
             raise ValueError(f"The mode should be 'min' or 'max'. Got {mode}.")
@@ -24,6 +25,7 @@ class Monitor:
         self.target = target
         self.saved_freq = saved_freq
         self.early_stop = math.inf if early_stop == 0 else early_stop
+        self.valid_freq = valid_freq
         self.best = -math.inf if self.mode == 'max' else math.inf
         self.not_improved_count = 0
 
@@ -81,7 +83,8 @@ class Monitor:
             'saved_freq': self.saved_freq,
             'early_stop': self.early_stop,
             'best': self.best,
-            'not_improved_count': self.not_improved_count
+            'not_improved_count': self.not_improved_count,
+            'valid_freq': self.valid_freq
         }
 
     def load_state_dict(self, state_dict):
@@ -97,6 +100,11 @@ class Monitor:
 
         if self.early_stop != state_dict['early_stop']:
             LOGGER.warning(f"The early_stop is changed from {state_dict['early_stop']} to {self.early_stop}.")
+
+        if self.valid_freq != state_dict['valid_freq']:
+            self.not_improved_count = 0
+            LOGGER.warning(f"The valid_freq is changed from {state_dict['valid_freq']} to {self.valid_freq}.")
+            LOGGER.warning(f"The not_improved_count is reset to 0.")
 
         if self.not_improved_count >= self.early_stop:
             LOGGER.critical(f"Load the checkpoint that should have to be early stopped.")

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -58,7 +58,7 @@ class Dataloader(DataLoader):
         """
         worker_info = torch.utils.data.get_worker_info()
         if worker_info is not None:
-            seed = worker_info.seed % (2 ** 32)
+            seed = worker_info.seed % (2 ** 32)  # Avoid ValueError: Seed must be between 0 and 2**32 - 1.
             np.random.seed(seed)
 
 

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -1,3 +1,4 @@
+import torch
 import numpy as np
 from torch.utils.data import DataLoader
 
@@ -12,6 +13,8 @@ class Dataloader(DataLoader):
     def __init__(self, dataset, batch_size=1, shuffle=False, sampler=None,
                  batch_sampler=None, num_workers=0, collate_fn=None, pin_memory=False,
                  drop_last=False, timeout=0, worker_init_fn=None, grad_accumulation_steps=1):
+        if worker_init_fn is None:
+            worker_init_fn = self._default_worker_init_fn
         super().__init__(dataset=dataset,
                          batch_size=batch_size,
                          shuffle=shuffle,
@@ -38,12 +41,25 @@ class Dataloader(DataLoader):
                                                                  total_steps=len(self._index_sampler),
                                                                  batch_size=batch_size,
                                                                  last_batch_size=last_batch_size)
+        else:
+            self.grad_accumulation_steps = None
 
     def __len__(self):
-        if (hasattr(self, 'grad_accumulation_steps') and self.drop_last and self.grad_accumulation_steps() != 1):
+        if self.grad_accumulation_steps is not None and self.drop_last and self.grad_accumulation_steps() != 1:
             return len(self._index_sampler) // self.grad_accumulation_steps() * self.grad_accumulation_steps()
         else:
             return len(self._index_sampler)
+
+    @staticmethod
+    def _default_worker_init_fn(worker_id):
+        """The default worker_init_fn to avoid replication of numpy random seed across child processes
+        Ref:
+            https://github.com/pytorch/pytorch/issues/5059
+        """
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is not None:
+            seed = worker_info.seed % (2 ** 32)
+            np.random.seed(seed)
 
 
 class GradAccumulationSteps:

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -40,8 +40,7 @@ class Dataloader(DataLoader):
                                                                  last_batch_size=last_batch_size)
 
     def __len__(self):
-        if (getattr(self, 'grad_accumulation_steps', None) is not None
-                and self.drop_last and self.grad_accumulation_steps() != 1):
+        if (hasattr(self, 'grad_accumulation_steps') and self.drop_last and self.grad_accumulation_steps() != 1):
             return len(self._index_sampler) // self.grad_accumulation_steps() * self.grad_accumulation_steps()
         else:
             return len(self._index_sampler)

--- a/src/data/transforms.py
+++ b/src/data/transforms.py
@@ -141,7 +141,8 @@ class BaseTransform:
 
 class ToTensor(BaseTransform):
     """Convert a tuple of numpy.ndarray to a tuple of torch.Tensor.
-    Default is to transform a tuple of numpy.ndarray to a tuple of channel-first torch.FloatTensor.
+    Default is to transform a tuple of numpy.ndarray to a tuple of channel-first torch.Tensor
+    which infer data types from the tuple of numpy.ndarray.
 
     Args:
         channel_first (bool, optional): Whether the data format of the output data is channel-first,
@@ -157,7 +158,7 @@ class ToTensor(BaseTransform):
         Args:
             imgs (tuple of numpy.ndarray): The images to be converted.
             dtypes (sequence of torch.dtype, optional): The dtypes of the converted images
-                (default: None, transform all the images' dtype to torch.float).
+                (default: None, infer data types from the images).
 
         Returns:
             imgs (tuple of torch.Tensor): The converted images.
@@ -168,7 +169,7 @@ class ToTensor(BaseTransform):
             raise ValueError('All of the images should be 2D or 3D with channels.')
 
         if dtypes is None:
-            dtypes = tuple(torch.float() for _ in range(len(imgs)))
+            dtypes = tuple(None for _ in range(len(imgs)))
         if len(dtypes) != len(imgs):
             raise ValueError('The number of the dtypes should be the same as the images.')
         imgs = tuple(torch.as_tensor(img, dtype=dtype) for img, dtype in zip(imgs, dtypes))

--- a/src/data/transforms.py
+++ b/src/data/transforms.py
@@ -559,7 +559,7 @@ class RandomElasticDeform(BaseTransform):
 
         # Set the parameters of the bspline transform randomly.
         params = np.array(bspline_transform.GetParameters())
-        params = params + np.array(tuple(random.gauss(0, self.sigma) for _ in range(params.shape[0])))
+        params = params + np.random.randn(params.shape[0]) * self.sigma
         if len(shape) == 3 and not self.do_z_deformation:
             params[0:len(params) // 3] = 0
         bspline_transform.SetParameters(tuple(params))

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,6 @@ import argparse
 import copy
 import logging
 import random
-import re
 import torch
 from box import Box
 from pathlib import Path
@@ -79,25 +78,23 @@ def main(args):
         net = _get_instance(src.model.nets, config.net).to(device)
 
         logging.info('Create the loss functions and corresponding weights.')
-        loss_fns, loss_weights = LossFns(), []
-        defaulted_loss_fns = [loss_fn for loss_fn in dir(torch.nn) if 'Loss' in loss_fn]
-        for config_loss in sorted(config.losses,
-                                  key=lambda config_loss: _snake_case(config_loss.get('alias', config_loss.name))):
+        loss_fns, loss_weights = LossFns(), LossWeights()
+        defaulted_loss_fns = tuple(loss_fn for loss_fn in dir(torch.nn) if 'Loss' in loss_fn)
+        for config_loss in config.losses:
             if config_loss.name in defaulted_loss_fns:
                 loss_fn = _get_instance(torch.nn, config_loss).to(device)
             else:
                 loss_fn = _get_instance(src.model.losses, config_loss).to(device)
             loss_weight = config_loss.get('weight', 1 / len(config.losses))
-            name = _snake_case(config_loss.get('alias', config_loss.name))
+            name = config_loss.get('alias', config_loss.name)
             setattr(loss_fns, name, loss_fn)
-            loss_weights.append(loss_weight)
-        loss_weights = torch.tensor(loss_weights, dtype=torch.float, device=device)
+            setattr(loss_weights, name, loss_weight)
 
         logging.info('Create the metric functions.')
         metric_fns = MetricFns()
         for config_metric in config.metrics:
             metric_fn = _get_instance(src.model.metrics, config_metric).to(device)
-            name = _snake_case(config_metric.get('alias', config_metric.name))
+            name = config_metric.get('alias', config_metric.name)
             setattr(metric_fns, name, metric_fn)
 
         logging.info('Create the optimizer.')
@@ -171,26 +168,24 @@ def main(args):
         net = _get_instance(src.model.nets, config.net).to(device)
 
         logging.info('Create the loss functions and corresponding weights.')
-        loss_fns, loss_weights = LossFns(), []
-        defaulted_loss_fns = [loss_fn for loss_fn in dir(torch.nn) if 'Loss' in loss_fn]
-        for config_loss in sorted(config.losses,
-                                  key=lambda config_loss: _snake_case(config_loss.get('alias', config_loss.name))):
+        loss_fns, loss_weights = LossFns(), LossWeights()
+        defaulted_loss_fns = tuple(loss_fn for loss_fn in dir(torch.nn) if 'Loss' in loss_fn)
+        for config_loss in config.losses:
             if config_loss.name in defaulted_loss_fns:
                 loss_fn = _get_instance(torch.nn, config_loss).to(device)
             else:
                 loss_fn = _get_instance(src.model.losses, config_loss).to(device)
             loss_weight = config_loss.get('weight', 1 / len(config.losses))
-            loss_name = _snake_case(config_loss.get('alias', config_loss.name))
-            setattr(loss_fns, loss_name, loss_fn)
-            loss_weights.append(loss_weight)
-        loss_weights = torch.tensor(loss_weights, dtype=torch.float, device=device)
+            name = config_loss.get('alias', config_loss.name)
+            setattr(loss_fns, name, loss_fn)
+            setattr(loss_weights, name, loss_weight)
 
         logging.info('Create the metric functions.')
         metric_fns = MetricFns()
         for config_metric in config.metrics:
             metric_fn = _get_instance(src.model.metrics, config_metric).to(device)
-            metric_name = _snake_case(config_metric.get('alias', config_metric.name))
-            setattr(metric_fns, metric_name, metric_fn)
+            name = config_metric.get('alias', config_metric.name)
+            setattr(metric_fns, name, metric_fn)
 
         logging.info('Create the predictor.')
         kwargs = {
@@ -212,23 +207,18 @@ def main(args):
         logging.info('End testing.')
 
 
-class BaseFns:
-    def __init__(self):
-        pass
+class Base:
+    """The Base class for easy debugging.
+    """
 
     def __getattr__(self, name):
         raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'. "
-                             f"Its attributes: {list(self.__dict__.keys())}")
+                             f"Its attributes: {list(self.__dict__.keys())}.")
 
 
-class LossFns(BaseFns):
-    def __init__(self):
-        super().__init__()
-
-
-class MetricFns(BaseFns):
-    def __init__(self):
-        super().__init__()
+LossFns = type('LossFns', (Base,))
+LossWeights = type('LossWeights', (Base,))
+MetricFns = type('MetricFns', (Base,))
 
 
 def _parse_args():
@@ -243,21 +233,14 @@ def _parse_args():
 def _get_instance(module, config, *args):
     """
     Args:
-        module (module): The python module.
-        config (Box): The config to create the class object.
+        module (MyClass): The defined module (class).
+        config (Box): The config to create the class instance.
 
     Returns:
-        instance (object): The class object defined in the module.
+        instance (MyClass): The defined class instance.
     """
     cls = getattr(module, config.name)
     return cls(*args, **config.get('kwargs', {}))
-
-
-def _snake_case(string):
-    """Convert a string into snake case form.
-    Ref: https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
-    """
-    return re.sub('((?<=[a-z0-9])[A-Z]|(?!^)(?<!_)[A-Z](?=[a-z]))', r'_\1', string).lower()
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -4,9 +4,9 @@ import logging
 import random
 import re
 import torch
-import yaml
 from box import Box
 from pathlib import Path
+from shutil import copyfile
 
 import src
 
@@ -18,9 +18,8 @@ def main(args):
     if not saved_dir.is_dir():
         saved_dir.mkdir(parents=True)
 
-    logging.info(f'Save the config to "{config.main.saved_dir}".')
-    with open(saved_dir / 'config.yaml', 'w+') as f:
-        yaml.dump(config.to_dict(), f, default_flow_style=False)
+    logging.info(f'Save the config to "{saved_dir}".')
+    copyfile(args.config_path, saved_dir / 'config.yaml')
 
     if not args.test:
         if config.trainer.kwargs.get('use_amp', False):

--- a/src/main.py
+++ b/src/main.py
@@ -118,6 +118,7 @@ def main(args):
 
         logging.info('Create the trainer.')
         kwargs = {
+            'saved_dir': saved_dir,
             'device': device,
             'train_dataloader': train_dataloader,
             'valid_dataloader': valid_dataloader,
@@ -189,6 +190,7 @@ def main(args):
 
         logging.info('Create the predictor.')
         kwargs = {
+            'saved_dir': saved_dir,
             'device': device,
             'test_dataloader': test_dataloader,
             'net': net,

--- a/src/main.py
+++ b/src/main.py
@@ -216,9 +216,9 @@ class Base:
                              f"Its attributes: {list(self.__dict__.keys())}.")
 
 
-LossFns = type('LossFns', (Base,))
-LossWeights = type('LossWeights', (Base,))
-MetricFns = type('MetricFns', (Base,))
+LossFns = type('LossFns', (Base,), {})
+LossWeights = type('LossWeights', (Base,), {})
+MetricFns = type('MetricFns', (Base,), {})
 
 
 def _parse_args():

--- a/src/model/losses.py
+++ b/src/model/losses.py
@@ -22,7 +22,7 @@ class BCELossWrapper(nn.Module):
         with_logits (bool, optional): Specify the output is logits or probability (default: True).
         weight (sequence, optional): The same argument in torch.nn.BCEWithLogitsLoss and torch.nn.BCELoss
             but its type is sequence for the configuration purpose (default: None).
-        pos_weight (sequence, optional): The same argument in torch.nn.BCEWithLogitsLoss and torch.nn.BCELoss
+        pos_weight (sequence, optional): The same argument in torch.nn.BCEWithLogitsLoss
             but its type is sequence for the configuration purpose (default: None).
     """
 
@@ -30,10 +30,10 @@ class BCELossWrapper(nn.Module):
         super().__init__()
         if weight is not None:
             weight = torch.tensor(weight, dtype=torch.float)
-            kwargs.update({'weight': weight})
+            kwargs.update(weight=weight)
         if pos_weight is not None:
             pos_weight = torch.tensor(pos_weight, dtype=torch.float)
-            kwargs.update({'pos_weight': pos_weight})
+            kwargs.update(pos_weight=pos_weight)
         self.loss_fn = (nn.BCEWithLogitsLoss if with_logits else nn.BCELoss)(**kwargs)
 
     def forward(self, output, target):
@@ -66,7 +66,7 @@ class CrossEntropyLossWrapper(nn.Module):
         super().__init__()
         if weight is not None:
             weight = torch.tensor(weight, dtype=torch.float)
-            kwargs.update({'weight': weight})
+            kwargs.update(weight=weight)
         self.loss_fn = (nn.CrossEntropyLoss if with_logits else nn.NLLLoss)(**kwargs)
 
     def forward(self, output, target):
@@ -84,27 +84,24 @@ class CrossEntropyLossWrapper(nn.Module):
 class DiceLoss(nn.Module):
     """The Dice loss.
     Refs:
+        https://arxiv.org/pdf/1606.04797
         https://github.com/pytorch/pytorch/issues/1249#issuecomment-337999895
 
     Args:
         binary (bool, optional): Whether to use the binary mode, which expects the task is
             binary classification, the activate function is sigmoid and output channel is 1
-            (similar to torch.nn.BCEWithLogitsLoss or torch.nn.BCELoss) (default: False).
+            (similar to torch.nn.BCEWithLogitsLoss and torch.nn.BCELoss) (default: False).
         with_logits (bool, optional): Specify the output is logits or probability (default: True).
         smooth (float, optional): The smooth term (default: 1.0).
         square (bool, optional): Whether to use the square of cardinality (default: True).
-        weight (sequence, optional): The weight given to each class (default: None).
     """
 
-    def __init__(self, binary=False, with_logits=True, smooth=1.0, square=True, weight=None):
+    def __init__(self, binary=False, with_logits=True, smooth=1.0, square=True):
         super().__init__()
         self.binary = binary
         self.with_logits = with_logits
         self.smooth = smooth
         self.square = square
-        if weight is not None:
-            weight = torch.tensor(weight, dtype=torch.float)
-            self.register_buffer('weight', weight)
 
     def forward(self, output, target):
         """
@@ -129,11 +126,7 @@ class DiceLoss(nn.Module):
             cardinality = (output ** 2).sum(reduced_dims) + (target ** 2).sum(reduced_dims)
         else:
             cardinality = output.sum(reduced_dims) + target.sum(reduced_dims)
-        loss = 1 - (2 * intersection + self.smooth) / (cardinality + self.smooth)
-        if hasattr(self, 'weight'):
-            loss = (self.weight * loss).sum(dim=1).mean()
-        else:
-            loss = loss.mean()
+        loss = (1 - (2 * intersection + self.smooth) / (cardinality + self.smooth)).mean()
         return loss
 
 
@@ -145,24 +138,20 @@ class TverskyLoss(nn.Module):
     Args:
         binary (bool, optional): Whether to use the binary mode, which expects the task is
             binary classification, the activate function is sigmoid and output channel is 1
-            (similar to torch.nn.BCEWithLogitsLoss or torch.nn.BCELoss) (default: False).
+            (similar to torch.nn.BCEWithLogitsLoss and torch.nn.BCELoss) (default: False).
         with_logits (bool, optional): Specify the output is logits or probability (default: True).
         alpha (float, optional): The magnitude of penalties for the False Positives (FPs) (default: 0.5).
         beta (float, optional): The magnitude of penalties for the False Negatives (FNs) (default: 0.5).
         smooth (float, optional): The smooth term (default: 1.0).
-        weight (sequence, optional): The weight given to each class (default: None).
     """
 
-    def __init__(self, binary=False, with_logits=True, alpha=0.5, beta=0.5, smooth=1.0, weight=None):
+    def __init__(self, binary=False, with_logits=True, alpha=0.5, beta=0.5, smooth=1.0):
         super().__init__()
         self.binary = binary
         self.with_logits = with_logits
         self.alpha = alpha
         self.beta = beta
         self.smooth = smooth
-        if weight is not None:
-            weight = torch.tensor(weight, dtype=torch.float)
-            self.register_buffer('weight', weight)
 
     def forward(self, output, target):
         """
@@ -185,9 +174,7 @@ class TverskyLoss(nn.Module):
         intersection = (output * target).sum(reduced_dims)
         fps = (output * (1 - target)).sum(reduced_dims)
         fns = ((1 - output) * target).sum(reduced_dims)
-        loss = 1 - (intersection + self.smooth) / (intersection + self.alpha * fps + self.beta * fns + self.smooth)
-        if hasattr(self, 'weight'):
-            loss = (self.weight * loss).sum(dim=1).mean()
-        else:
-            loss = loss.mean()
+        loss = (
+            1 - (intersection + self.smooth) / (intersection + self.alpha * fps + self.beta * fns + self.smooth)
+        ).mean()
         return loss

--- a/src/model/losses.py
+++ b/src/model/losses.py
@@ -1,0 +1,125 @@
+import torch
+import torch.nn as nn
+
+__all__ = [
+    'CrossEntropyLossWrapper',
+    'DiceLoss',
+    'TverskyLoss',
+]
+
+
+class CrossEntropyLossWrapper(nn.Module):
+    """The cross-entropy loss wrapper.
+    Args:
+        weight (sequence, optional): The weight given to each class (default: None).
+    """
+
+    def __init__(self, weight=None, **kwargs):
+        super().__init__()
+        if weight is not None:
+            weight = torch.tensor(weight, dtype=torch.float)
+            kwargs.update({'weight': weight})
+        self.loss_fn = nn.CrossEntropyLoss(**kwargs)
+
+    def forward(self, output, target):
+        """
+        Args:
+            output (torch.Tensor) (N, C, *): The output logits.
+            target (torch.LongTensor) (N, *): The target where each value is between 0 and C-1.
+
+        Returns:
+            loss (torch.Tensor) (0): The cross entropy loss.
+        """
+        return self.loss_fn(output, target)
+
+
+class DiceLoss(nn.Module):
+    """The Dice loss.
+    Refs:
+        https://github.com/pytorch/pytorch/issues/1249#issuecomment-337999895
+
+    Args:
+        smooth (float, optional): The smooth term (default: 1.0).
+        square (bool, optional): Whether to use the square of cardinality (default: True).
+        weight (sequence, optional): The weight given to each class (default: None).
+    """
+
+    def __init__(self, smooth=1.0, square=True, weight=None):
+        super().__init__()
+        self.smooth = smooth
+        self.square = square
+        if weight is not None:
+            weight = torch.tensor(weight, dtype=torch.float)
+            self.register_buffer('weight', weight)
+
+    def forward(self, output, target):
+        """
+        Args:
+            output (torch.Tensor) (N, C, *): The output probability.
+            target (torch.LongTensor) (N, 1, *): The target where each value is between 0 and C-1.
+
+        Returns:
+            loss (torch.Tensor) (0): The dice loss.
+        """
+        # Get the one-hot encoding of the ground truth label.
+        target = torch.zeros_like(output).scatter_(1, target, 1)
+
+        # Calculate the dice loss.
+        reduced_dims = tuple(range(2, output.dim()))  # (N, C, *) --> (N, C)
+        intersection = (output * target).sum(reduced_dims)
+        if self.square:
+            cardinality = (output ** 2).sum(reduced_dims) + (target ** 2).sum(reduced_dims)
+        else:
+            cardinality = output.sum(reduced_dims) + target.sum(reduced_dims)
+        loss = 1 - (2 * intersection + self.smooth) / (cardinality + self.smooth)
+        if getattr(self, 'weight', None) is not None:
+            loss = (self.weight * loss).sum(dim=1).mean()
+        else:
+            loss = loss.mean()
+        return loss
+
+
+class TverskyLoss(nn.Module):
+    """The Tversky loss.
+    Refs:
+        https://arxiv.org/abs/1706.05721
+
+    Args:
+        alpha (float): The magnitude of penalties for the False Positives (FPs).
+        beta (float): The magnitude of penalties for the False Negatives (FNs).
+        smooth (float, optional): The smooth term (default: 1.0).
+        weight (sequence, optional): The weight given to each class (default: None).
+    """
+
+    def __init__(self, alpha, beta, smooth=1.0, weight=None):
+        super().__init__()
+        self.alpha = alpha
+        self.beta = beta
+        self.smooth = smooth
+        if weight is not None:
+            weight = torch.tensor(weight, dtype=torch.float)
+            self.register_buffer('weight', weight)
+
+    def forward(self, output, target):
+        """
+        Args:
+            output (torch.Tensor) (N, C, *): The output probability.
+            target (torch.LongTensor) (N, 1, *): The target where each value is between 0 and C-1.
+
+        Returns:
+            loss (torch.Tensor) (0): The tversky loss.
+        """
+        # Get the one-hot encoding of the ground truth label.
+        target = torch.zeros_like(output).scatter_(1, target, 1)
+
+        # Calculate the tversky loss.
+        reduced_dims = tuple(range(2, output.dim()))  # (N, C, *) --> (N, C)
+        intersection = (output * target).sum(reduced_dims)
+        fps = (output * (1 - target)).sum(reduced_dims)
+        fns = ((1 - output) * target).sum(reduced_dims)
+        loss = 1 - (intersection + self.smooth) / (intersection + self.alpha * fps + self.beta * fns + self.smooth)
+        if getattr(self, 'weight', None) is not None:
+            loss = (self.weight * loss).sum(dim=1).mean()
+        else:
+            loss = loss.mean()
+        return loss

--- a/src/model/losses.py
+++ b/src/model/losses.py
@@ -1,30 +1,78 @@
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 __all__ = [
+    'BCELossWrapper',
     'CrossEntropyLossWrapper',
     'DiceLoss',
     'TverskyLoss',
 ]
 
 
-class CrossEntropyLossWrapper(nn.Module):
-    """The cross-entropy loss wrapper.
+class BCELossWrapper(nn.Module):
+    """The binary cross-entropy loss wrapper which combines torch.nn.BCEWithLogitsLoss (with logits)
+    and torch.nn.BCELoss (with probability).
+
+    Ref: 
+        https://pytorch.org/docs/stable/nn.html#bcewithlogitsloss
+        https://pytorch.org/docs/stable/nn.html#bceloss
+
     Args:
-        weight (sequence, optional): The weight given to each class (default: None).
+        with_logits (bool, optional): Specify the output is logits or probability (default: True).
+        weight (sequence, optional): The same argument in torch.nn.BCEWithLogitsLoss and torch.nn.BCELoss
+            but its type is sequence for the configuration purpose (default: None).
+        pos_weight (sequence, optional): The same argument in torch.nn.BCEWithLogitsLoss and torch.nn.BCELoss
+            but its type is sequence for the configuration purpose (default: None).
     """
 
-    def __init__(self, weight=None, **kwargs):
+    def __init__(self, with_logits=True, weight=None, pos_weight=None, **kwargs):
         super().__init__()
         if weight is not None:
             weight = torch.tensor(weight, dtype=torch.float)
             kwargs.update({'weight': weight})
-        self.loss_fn = nn.CrossEntropyLoss(**kwargs)
+        if pos_weight is not None:
+            pos_weight = torch.tensor(pos_weight, dtype=torch.float)
+            kwargs.update({'pos_weight': pos_weight})
+        self.loss_fn = (nn.BCEWithLogitsLoss if with_logits else nn.BCELoss)(**kwargs)
 
     def forward(self, output, target):
         """
         Args:
-            output (torch.Tensor) (N, C, *): The output logits.
+            output (torch.Tensor) (N, *): The output logits or probability.
+            target (torch.LongTensor) (N, *): The target where each value is 0 or 1.
+
+        Returns:
+            loss (torch.Tensor) (0): The binary cross entropy loss.
+        """
+        return self.loss_fn(output, target)
+
+
+class CrossEntropyLossWrapper(nn.Module):
+    """The cross-entropy loss wrapper which combines torch.nn.CrossEntropyLoss (with logits)
+    and torch.nn.NLLLoss (with probability).
+
+    Ref: 
+        https://pytorch.org/docs/stable/nn.html#crossentropyloss
+        https://pytorch.org/docs/stable/nn.html#nllloss
+
+    Args:
+        with_logits (bool, optional): Specify the output is logits or probability (default: True).
+        weight (sequence, optional): The same argument in torch.nn.CrossEntropyLoss and torch.nn.NLLLoss
+            but its type is sequence for the configuration purpose (default: None).
+    """
+
+    def __init__(self, with_logits=True, weight=None, **kwargs):
+        super().__init__()
+        if weight is not None:
+            weight = torch.tensor(weight, dtype=torch.float)
+            kwargs.update({'weight': weight})
+        self.loss_fn = (nn.CrossEntropyLoss if with_logits else nn.NLLLoss)(**kwargs)
+
+    def forward(self, output, target):
+        """
+        Args:
+            output (torch.Tensor) (N, C, *): The output logits or probability.
             target (torch.LongTensor) (N, *): The target where each value is between 0 and C-1.
 
         Returns:
@@ -39,13 +87,19 @@ class DiceLoss(nn.Module):
         https://github.com/pytorch/pytorch/issues/1249#issuecomment-337999895
 
     Args:
+        binary (bool, optional): Whether to use the binary mode, which expects the task is
+            binary classification, the activate function is sigmoid and output channel is 1
+            (similar to torch.nn.BCEWithLogitsLoss or torch.nn.BCELoss) (default: False).
+        with_logits (bool, optional): Specify the output is logits or probability (default: True).
         smooth (float, optional): The smooth term (default: 1.0).
         square (bool, optional): Whether to use the square of cardinality (default: True).
         weight (sequence, optional): The weight given to each class (default: None).
     """
 
-    def __init__(self, smooth=1.0, square=True, weight=None):
+    def __init__(self, binary=False, with_logits=True, smooth=1.0, square=True, weight=None):
         super().__init__()
+        self.binary = binary
+        self.with_logits = with_logits
         self.smooth = smooth
         self.square = square
         if weight is not None:
@@ -55,14 +109,18 @@ class DiceLoss(nn.Module):
     def forward(self, output, target):
         """
         Args:
-            output (torch.Tensor) (N, C, *): The output probability.
+            output (torch.Tensor) (N, C, *) or (N, 1, *): The output logits or probability.
             target (torch.LongTensor) (N, 1, *): The target where each value is between 0 and C-1.
 
         Returns:
             loss (torch.Tensor) (0): The dice loss.
         """
+        if self.with_logits:
+            output = F.sigmoid(output) if self.binary else F.softmax(output, dim=1)
+
         # Get the one-hot encoding of the ground truth label.
-        target = torch.zeros_like(output).scatter_(1, target, 1)
+        if not self.binary:
+            target = torch.zeros_like(output).scatter_(1, target, 1)
 
         # Calculate the dice loss.
         reduced_dims = tuple(range(2, output.dim()))  # (N, C, *) --> (N, C)
@@ -72,7 +130,7 @@ class DiceLoss(nn.Module):
         else:
             cardinality = output.sum(reduced_dims) + target.sum(reduced_dims)
         loss = 1 - (2 * intersection + self.smooth) / (cardinality + self.smooth)
-        if getattr(self, 'weight', None) is not None:
+        if hasattr(self, 'weight'):
             loss = (self.weight * loss).sum(dim=1).mean()
         else:
             loss = loss.mean()
@@ -85,14 +143,20 @@ class TverskyLoss(nn.Module):
         https://arxiv.org/abs/1706.05721
 
     Args:
-        alpha (float): The magnitude of penalties for the False Positives (FPs).
-        beta (float): The magnitude of penalties for the False Negatives (FNs).
+        binary (bool, optional): Whether to use the binary mode, which expects the task is
+            binary classification, the activate function is sigmoid and output channel is 1
+            (similar to torch.nn.BCEWithLogitsLoss or torch.nn.BCELoss) (default: False).
+        with_logits (bool, optional): Specify the output is logits or probability (default: True).
+        alpha (float, optional): The magnitude of penalties for the False Positives (FPs) (default: 0.5).
+        beta (float, optional): The magnitude of penalties for the False Negatives (FNs) (default: 0.5).
         smooth (float, optional): The smooth term (default: 1.0).
         weight (sequence, optional): The weight given to each class (default: None).
     """
 
-    def __init__(self, alpha, beta, smooth=1.0, weight=None):
+    def __init__(self, binary=False, with_logits=True, alpha=0.5, beta=0.5, smooth=1.0, weight=None):
         super().__init__()
+        self.binary = binary
+        self.with_logits = with_logits
         self.alpha = alpha
         self.beta = beta
         self.smooth = smooth
@@ -103,14 +167,18 @@ class TverskyLoss(nn.Module):
     def forward(self, output, target):
         """
         Args:
-            output (torch.Tensor) (N, C, *): The output probability.
+            output (torch.Tensor) (N, C, *) or (N, 1, *): The output logits or probability.
             target (torch.LongTensor) (N, 1, *): The target where each value is between 0 and C-1.
 
         Returns:
             loss (torch.Tensor) (0): The tversky loss.
         """
+        if self.with_logits:
+            output = F.sigmoid(output) if self.binary else F.softmax(output, dim=1)
+
         # Get the one-hot encoding of the ground truth label.
-        target = torch.zeros_like(output).scatter_(1, target, 1)
+        if not self.binary:
+            target = torch.zeros_like(output).scatter_(1, target, 1)
 
         # Calculate the tversky loss.
         reduced_dims = tuple(range(2, output.dim()))  # (N, C, *) --> (N, C)
@@ -118,7 +186,7 @@ class TverskyLoss(nn.Module):
         fps = (output * (1 - target)).sum(reduced_dims)
         fns = ((1 - output) * target).sum(reduced_dims)
         loss = 1 - (intersection + self.smooth) / (intersection + self.alpha * fps + self.beta * fns + self.smooth)
-        if getattr(self, 'weight', None) is not None:
+        if hasattr(self, 'weight'):
             loss = (self.weight * loss).sum(dim=1).mean()
         else:
             loss = loss.mean()

--- a/src/model/metrics.py
+++ b/src/model/metrics.py
@@ -16,13 +16,15 @@ class Dice(nn.Module):
     def forward(self, output, target):
         """
         Args:
-            output (torch.Tensor) (N, C, *): The output probability.
+            output (torch.Tensor) (N, C, *) or (N, 1, *): The output probability.
             target (torch.LongTensor) (N, 1, *): The target where each value is between 0 and C-1.
 
         Returns:
             metric (torch.Tensor) (C): The dice scores for each class.
         """
         # Get the one-hot encoding of the prediction and the ground truth label.
+        if output.size(1) == 1:  # (N, 1, *) --> (N, 2, *)
+            pred = torch.cat((1 - output, output), dim=1)
         pred = output.argmax(dim=1, keepdim=True)
         pred = torch.zeros_like(output).scatter_(1, pred, 1)
         target = torch.zeros_like(output).scatter_(1, target, 1)

--- a/src/model/metrics.py
+++ b/src/model/metrics.py
@@ -1,0 +1,35 @@
+import torch
+import torch.nn as nn
+
+__all__ = [
+    'Dice',
+]
+
+
+class Dice(nn.Module):
+    """The Dice score.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, output, target):
+        """
+        Args:
+            output (torch.Tensor) (N, C, *): The output probability.
+            target (torch.LongTensor) (N, 1, *): The target where each value is between 0 and C-1.
+
+        Returns:
+            metric (torch.Tensor) (C): The dice scores for each class.
+        """
+        # Get the one-hot encoding of the prediction and the ground truth label.
+        pred = output.argmax(dim=1, keepdim=True)
+        pred = torch.zeros_like(output).scatter_(1, pred, 1)
+        target = torch.zeros_like(output).scatter_(1, target, 1)
+
+        # Calculate the dice scores for each class.
+        reduced_dims = tuple(range(2, output.dim()))  # (N, C, *) --> (N, C)
+        intersection = (pred * target).sum(reduced_dims)
+        cardinality = pred.sum(reduced_dims) + target.sum(reduced_dims)
+        score = (2 * intersection / cardinality.clamp(min=1)).mean(dim=0)
+        return score

--- a/src/runner/predictors/base_predictor.py
+++ b/src/runner/predictors/base_predictor.py
@@ -14,7 +14,7 @@ class BasePredictor:
         test_dataloader (Dataloader): The testing dataloader.
         net (BaseNet): The network architecture.
         loss_fns (LossFns): The loss functions.
-        loss_weights (torch.Tensor): The corresponding weights of loss functions.
+        loss_weights (LossWeights): The corresponding weights of loss functions.
         metric_fns (MetricFns): The metric functions.
     """
 
@@ -37,9 +37,8 @@ class BasePredictor:
         for i, batch in enumerate(pbar):
             with torch.no_grad():
                 test_dict = self._test_step(batch)
-                losses = test_dict['losses']
-                _, _losses = zip(*sorted(losses.items()))
-                loss = (torch.stack(_losses) * self.loss_weights).sum()
+                loss = test_dict['loss']
+                losses = test_dict.get('losses')
                 metrics = test_dict.get('metrics')
 
             if (i + 1) == len(dataloader) and not dataloader.drop_last:
@@ -59,7 +58,8 @@ class BasePredictor:
 
         Returns:
             test_dict (dict): The computed results.
-                test_dict['losses'] (dict)
+                test_dict['loss'] (torch.Tensor)
+                test_dict['losses'] (dict, optional)
                 test_dict['metrics'] (dict, optional)
         """
         raise NotImplementedError

--- a/src/runner/predictors/base_predictor.py
+++ b/src/runner/predictors/base_predictor.py
@@ -37,7 +37,10 @@ class BasePredictor:
         for i, batch in enumerate(pbar):
             with torch.no_grad():
                 test_dict = self._test_step(batch)
-                loss = test_dict['loss']
+                loss = test_dict.get('loss')
+                if loss is None:
+                    raise KeyError(f"The test_dict must have the key named 'loss'. "
+                                   'Please check the returned keys as defined in MyPredictor._test_step().')
                 losses = test_dict.get('losses')
                 metrics = test_dict.get('metrics')
 

--- a/src/runner/predictors/base_predictor.py
+++ b/src/runner/predictors/base_predictor.py
@@ -10,6 +10,7 @@ LOGGER = logging.getLogger(__name__.split('.')[-1])
 class BasePredictor:
     """The base class for all predictors.
     Args:
+        saved_dir (Path): The root directory of the saved data.
         device (torch.device): The device.
         test_dataloader (Dataloader): The testing dataloader.
         net (BaseNet): The network architecture.
@@ -18,7 +19,9 @@ class BasePredictor:
         metric_fns (MetricFns): The metric functions.
     """
 
-    def __init__(self, device, test_dataloader, net, loss_fns, loss_weights, metric_fns):
+    def __init__(self, saved_dir, device, test_dataloader,
+                 net, loss_fns, loss_weights, metric_fns):
+        self.saved_dir = saved_dir
         self.device = device
         self.test_dataloader = test_dataloader
         self.net = net.to(device)
@@ -37,10 +40,7 @@ class BasePredictor:
         for i, batch in enumerate(pbar):
             with torch.no_grad():
                 test_dict = self._test_step(batch)
-                loss = test_dict.get('loss')
-                if loss is None:
-                    raise KeyError(f"The test_dict must have the key named 'loss'. "
-                                   'Please check the returned keys as defined in MyPredictor._test_step().')
+                loss = test_dict['loss']
                 losses = test_dict.get('losses')
                 metrics = test_dict.get('metrics')
 

--- a/src/runner/trainers/base_trainer.py
+++ b/src/runner/trainers/base_trainer.py
@@ -65,6 +65,7 @@ class BaseTrainer:
         """
         while self.epoch <= self.num_epochs:
             # Do training and validation.
+            print(end='\n\n')
             LOGGER.info(f'Epoch {self.epoch}.')
             train_log, train_batch, train_outputs = self._run_epoch('train')
             LOGGER.info(f'Train log: {train_log}.')

--- a/src/runner/trainers/base_trainer.py
+++ b/src/runner/trainers/base_trainer.py
@@ -21,7 +21,7 @@ class BaseTrainer:
         valid_dataloader (Dataloader): The validation dataloader.
         net (BaseNet): The network architecture.
         loss_fns (LossFns): The loss functions.
-        loss_weights (torch.Tensor): The corresponding weights of loss functions.
+        loss_weights (LossWeights): The corresponding weights of loss functions.
         metric_fns (MetricFns): The metric functions.
         optimizer (torch.optim.Optimizer): The algorithm to train the network.
         lr_scheduler (torch.optim.lr_scheduler): The scheduler to adjust the learning rate.
@@ -143,9 +143,8 @@ class BaseTrainer:
             for i in range(len(dataloader)):
                 batch = next(dataloader_iterator)
                 train_dict = self._train_step(batch)
-                losses = train_dict['losses']
-                _, _losses = zip(*sorted(losses.items()))
-                loss = (torch.stack(_losses) * self.loss_weights).sum()
+                loss = train_dict['loss']
+                losses = train_dict.get('losses')
                 metrics = train_dict.get('metrics')
                 outputs = train_dict.get('outputs')
 
@@ -189,9 +188,8 @@ class BaseTrainer:
             for i, batch in enumerate(pbar):
                 with torch.no_grad():
                     valid_dict = self._valid_step(batch)
-                    losses = valid_dict['losses']
-                    _, _losses = zip(*sorted(losses.items()))
-                    loss = (torch.stack(_losses) * self.loss_weights).sum()
+                    loss = valid_dict['loss']
+                    losses = valid_dict.get('losses')
                     metrics = valid_dict.get('metrics')
                     outputs = valid_dict.get('outputs')
 
@@ -211,7 +209,8 @@ class BaseTrainer:
 
         Returns:
             train_dict (dict): The computed results.
-                train_dict['losses'] (dict)
+                train_dict['loss'] (torch.Tensor)
+                train_dict['losses'] (dict, optional)
                 train_dict['metrics'] (dict, optional)
                 train_dict['outputs'] (dict, optional)
         """
@@ -224,7 +223,8 @@ class BaseTrainer:
 
         Returns:
             valid_dict (dict): The computed results.
-                valid_dict['losses'] (dict)
+                valid_dict['loss'] (torch.Tensor)
+                valid_dict['losses'] (dict, optional)
                 valid_dict['metrics'] (dict, optional)
                 valid_dict['outputs'] (dict, optional)
         """

--- a/src/runner/trainers/base_trainer.py
+++ b/src/runner/trainers/base_trainer.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__.split('.')[-1])
 class BaseTrainer:
     """The base class for all trainers.
     Args:
+        saved_dir (Path): The root directory of the saved data.
         device (torch.device): The device.
         train_dataloader (Dataloader): The training dataloader.
         valid_dataloader (Dataloader): The validation dataloader.
@@ -33,10 +34,11 @@ class BaseTrainer:
         opt_level (str): The optimization level of apex.amp (default: 'O1').
     """
 
-    def __init__(self, device, train_dataloader, valid_dataloader,
+    def __init__(self, saved_dir, device, train_dataloader, valid_dataloader,
                  net, loss_fns, loss_weights, metric_fns, optimizer,
                  lr_scheduler, logger, monitor, num_epochs,
                  valid_freq=1, use_amp=False, opt_level='O1'):
+        self.saved_dir = saved_dir
         self.device = device
         self.train_dataloader = train_dataloader
         self.valid_dataloader = valid_dataloader

--- a/src/runner/trainers/base_trainer.py
+++ b/src/runner/trainers/base_trainer.py
@@ -35,9 +35,8 @@ class BaseTrainer:
     """
 
     def __init__(self, saved_dir, device, train_dataloader, valid_dataloader,
-                 net, loss_fns, loss_weights, metric_fns, optimizer,
-                 lr_scheduler, logger, monitor, num_epochs,
-                 use_amp=False, opt_level='O1'):
+                 net, loss_fns, loss_weights, metric_fns, optimizer, lr_scheduler,
+                 logger, monitor, num_epochs, use_amp=False, opt_level='O1'):
         self.saved_dir = saved_dir
         self.device = device
         self.train_dataloader = train_dataloader
@@ -86,20 +85,19 @@ class BaseTrainer:
 
             if self.epoch % self.monitor.valid_freq == 0:
                 # Save the best checkpoint.
-                saved_path = self.monitor.is_best(valid_log)
+                saved_path = self.monitor.is_best(self.epoch, valid_log)
                 if saved_path is not None:
                     LOGGER.info(f'Save the best checkpoint to {saved_path} '
-                                f'({self.monitor.mode} {self.monitor.target}: {self.monitor.best}).')
+                                f'({self.monitor.mode} {self.monitor.target}: {self.monitor.best_score}).')
                     self.save(saved_path)
                 else:
-                    epoch = self.epoch - self.monitor.not_improved_count * self.monitor.valid_freq
-                    LOGGER.info(f'The best checkpoint is remained at epoch {epoch} '
-                                f'({self.monitor.mode} {self.monitor.target}: {self.monitor.best}).')
+                    LOGGER.info(f'The best checkpoint is remained at epoch {self.monitor.best_epoch} '
+                                f'({self.monitor.mode} {self.monitor.target}: {self.monitor.best_score}).')
 
                 # Save the regular checkpoint.
                 saved_path = self.monitor.is_saved(self.epoch)
                 if saved_path is not None:
-                    LOGGER.info(f'Save the checkpoint to {saved_path}.')
+                    LOGGER.info(f'Save the regular checkpoint to {saved_path}.')
                     self.save(saved_path)
 
                 # Early stop.
@@ -110,7 +108,7 @@ class BaseTrainer:
                 # Save the regular checkpoint.
                 saved_path = self.monitor.is_saved(self.epoch)
                 if saved_path is not None:
-                    LOGGER.info(f'Save the checkpoint to {saved_path}.')
+                    LOGGER.info(f'Save the regular checkpoint to {saved_path}.')
                     self.save(saved_path)
 
             self.epoch += 1

--- a/src/runner/trainers/base_trainer.py
+++ b/src/runner/trainers/base_trainer.py
@@ -3,6 +3,7 @@ import logging
 import math
 import random
 import torch
+import numpy as np
 from torch.optim.lr_scheduler import (
     CyclicLR, OneCycleLR, CosineAnnealingWarmRestarts, ReduceLROnPlateau
 )
@@ -249,6 +250,7 @@ class BaseTrainer:
             'monitor': self.monitor.state_dict(),
             'epoch': self.epoch,
             'random_state': random.getstate(),
+            'np_random_state': np.random.get_state(),
             'torch_random_state': torch.get_rng_state(),
             'torch_cuda_random_state': torch.cuda.get_rng_state_all()
         }, path)
@@ -279,5 +281,6 @@ class BaseTrainer:
         self.monitor.load_state_dict(checkpoint['monitor'])
         self.epoch = checkpoint['epoch'] + 1
         random.setstate(checkpoint['random_state'])
+        np.random.set_state(checkpoint['np_random_state'])
         torch.set_rng_state(checkpoint['torch_random_state'])
         torch.cuda.set_rng_state_all(checkpoint['torch_cuda_random_state'])

--- a/src/runner/utils.py
+++ b/src/runner/utils.py
@@ -12,7 +12,7 @@ class EpochLog:
         self.log = None
 
     def _init_log(self, losses=None, metrics=None):
-        """Initilize the log.
+        """Initialize the log.
         Args:
             losses (dict, optional): The computed losses (default: None).
             metrics (dict, optional): The computed metrics (default: None).

--- a/src/runner/utils.py
+++ b/src/runner/utils.py
@@ -11,34 +11,36 @@ class EpochLog:
         self.count = 0
         self.log = None
 
-    def _init_log(self, losses, metrics=None):
+    def _init_log(self, losses=None, metrics=None):
         """Initilize the log.
         Args:
-            losses (dict): The computed losses.
-            metrics (dict): The computed metrics.
+            losses (dict, optional): The computed losses (default: None).
+            metrics (dict, optional): The computed metrics (default: None).
         """
         self.log = {}
         self.log['loss'] = 0
-        for loss_name in losses.keys():
-            self.log[loss_name] = 0
+        if losses is not None:
+            for loss_name in losses.keys():
+                self.log[loss_name] = 0
         if metrics is not None:
             for metric_name in metrics.keys():
                 self.log[metric_name] = 0
 
-    def update(self, batch_size, loss, losses, metrics=None):
+    def update(self, batch_size, loss, losses=None, metrics=None):
         """Accumulate the computed losses and metrics.
         Args:
-            loss (torch.Tensor): The weighted sum of the computed losses.
-            losses (dict): The computed losses.
-            metrics (dict): The computed metrics.
             batch_size (int): The batch size.
+            loss (torch.Tensor): The computed loss.
+            losses (dict, optional): The computed losses (default: None).
+            metrics (dict, optional): The computed metrics (default: None).
         """
         self.count += batch_size
         if self.log is None:
             self._init_log(losses, metrics)
         self.log['loss'] += loss.item() * batch_size
-        for loss_name, loss in losses.items():
-            self.log[loss_name] += loss.item() * batch_size
+        if losses is not None:
+            for loss_name, loss in losses.items():
+                self.log[loss_name] += loss.item() * batch_size
         if metrics is not None:
             for metric_name, metric in metrics.items():
                 self.log[metric_name] += metric.item() * batch_size


### PR DESCRIPTION
- Transform related
  - Set compose as the factory method of `Compose`
  - `Compose` instance will still return tuple even if there is only one image.

     ```python
     img = np.array([0, 1])
     to_tensor = Compose([ToTensor()])
     img = to_tensor(img) # (old)
     img, = to_tensor(img) # (now)
     ```
  - New interface for transforms runtime kwargs and use `transformed` to specify whether the corresponding image should be transformed.
     ```python
     img1, img2, img3 = np.array([0, 1]), np.array([0, 1]), np.array([0, 1])
     to_tensor = Compose([ToTensor()])
     transforms_kwargs = {
         'ToTensor':{
             'transformed': (True, True, False)
             'dtypes': (torch.float, torch.long)
         }
     }
     img1, img2, img3 = to_tensor(img1, img2, img3, **transforms_kwargs)
     print(img1.dtype) # torch.float
     print(img2.dtype) # torch.long
     print(type(img3)) # numpy.ndarray
     ```
  - ToTensor new argument `channel_first` (default is `True`)
     If `channel_first is True`, the data format will be `CHW`, `CDHW`.
     New default behavior: infer the data type of the input images (`numpy.ndarry`).
  - New transforms
    - `MinMaxScale`
    - `Clip`
    - `Resample`
    - `RandomElasticDeform` (renamed)
- New Losses and Metrics
  - `CrossEntropyLoss`
  - `DiceLoss`
  - `TverskyLoss`
  - `Dice`
- `LossFns`, `LossWeights` and `MetricFns` are `namedtuple`, so they are indexable and iterable.
- Miscellaneous
  - The config file is copied instead of dumped.
  - Do not implicitly change `LossFns` and `MetricFns` attributes to snake case.
  - Use `LossWeights` type for user-defined weighting the computed losses (has the same usage as `LossFns` and `MetricFns`).
  - Add error messages in `Monitor` for easy debugging.
  - Add new attr `saved_dir` to `BaseTrainer` and `BasePredictor`.
  - `metric_fns` is optional now and can be a loss_fn defined in `torch.nn`.
  - Avoid replication of numpy random seed across child processes.
  - Move the `valid_freq` from `BaseTrainer` to `Monitor`.
  - Closes #23.